### PR TITLE
Config上書き時にウインドウモードが不正になって自動でウインドウモードになってしまいます。

### DIFF
--- a/CameraPlus/ConfigEntity.cs
+++ b/CameraPlus/ConfigEntity.cs
@@ -5,7 +5,7 @@
 		public string version = "1.6.0";
 		public int windowResolutionWidth = 1280;
 		public int windowResolutionHeight = 720;
-		public MainSettingsModelSO.WindowMode windowMode = MainSettingsModelSO.WindowMode.Fullscreen;
+		public int windowMode = (int)MainSettingsModelSO.WindowMode.Fullscreen;
 		public float vrResolutionScale = 1.0f;
 		public float menuVRResolutionScaleMultiplier = 1.0f;
 		public bool useFixedFoveatedRenderingDuringGameplay = false;


### PR DESCRIPTION
UnityのJsonUtilityとNewtonJsonのenum書き込み処理時の違いで不具合が起きています。
一応ConfigEntityで対応しましたが今後設定項目が増減することを考えるとSimpleJsonで書き込んだ方がいいかも？