### PR TITLE
Add more robust fpfc check

### DIFF
--- a/CameraPlus/CameraPlusBehaviour.cs
+++ b/CameraPlus/CameraPlusBehaviour.cs
@@ -113,7 +113,7 @@ namespace CameraPlus
 
             Config = config;
             _isMainCamera = Path.GetFileName(Config.FilePath) == $"{Plugin.MainCamera}.cfg";
-            _contextMenuEnabled = !Environment.CommandLine.Contains("fpfc");
+            _contextMenuEnabled = Array.IndexOf(Environment.GetCommandLineArgs(), "fpfc") == -1;
 
             StartCoroutine(DelayedInit());
         }


### PR DESCRIPTION
This took me a while to figure out - I usually "remove" fpfc from my launch options by appending some character to it, this will disable its functionality but make it just that little bit easier to reuse in the future, but since Camera+ just checks if the cmdline string contains "fpfc" I was unable to open its context menu. I guess it cant hurt to have this more suffisticated check :)