### PR TITLE
Added Note & Custom Note culling to Camera+ Culling mask

### DIFF
--- a/CameraPlus/CameraPlusBehaviour.cs
+++ b/CameraPlus/CameraPlusBehaviour.cs
@@ -692,8 +692,8 @@ namespace CameraPlus
                 builder &= ~(1 << UILayer);
             else
                 builder |= (1 << UILayer);
-            builder &= ~(1 << (int)CustomNoteLayer);
-            builder |= 1 << (int)NoteLayer;
+            builder &= ~(1 << CustomNoteLayer);
+            builder |= 1 << NoteLayer;
             _cam.cullingMask = builder;
         }
 

--- a/CameraPlus/CameraPlusBehaviour.cs
+++ b/CameraPlus/CameraPlusBehaviour.cs
@@ -32,6 +32,8 @@ namespace CameraPlus
         protected const int OnlyInFirstPerson = 6; //Moved to an empty layer because layer 4 overlapped the floor
         protected const int NotesDebriLayer = 9;
         protected const int AlwaysVisible = 10;
+        protected const int NoteLayer = 8;
+        protected const int CustomNoteLayer = 24;
 
         public bool ThirdPerson {
             get { return _thirdPerson; }
@@ -690,7 +692,8 @@ namespace CameraPlus
                 builder &= ~(1 << UILayer);
             else
                 builder |= (1 << UILayer);
-
+            builder &= ~(1 << (int)CustomNoteLayer);
+            builder |= 1 << (int)NoteLayer;
             _cam.cullingMask = builder;
         }
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ ex)
 2. movementScriptpath = "ExampleMovementScript.json"
 
 **for Users of locales that use commas for decimal points**
+
 If the move script doesn't work, enclose the number in double quotation marks. Also, use commas for decimal points.
+
+
 ```xml
 {
     "ActiveInPauseMenu": true,     "ActiveInPauseMenu": Determines whether the camera pauses when pausing the game.


### PR DESCRIPTION
The new "HMD Only" feature of Custom Notes adds an option to put Custom Notes on layer 24 and normal notes on layer 8.
This allows the user to see custom notes in-headset while showing normal notes on the monitor.

For obvious reasons, this requires Camera+ to never display layer 24 and always display layer 8. Very simple fix, just makes sure that  those two layers are always displayed accordingly.