### PR TITLE
[New Feature] Green Screen Mode

### DIFF
--- a/CameraPlus/Behaviours/CameraPlusBehaviour.cs
+++ b/CameraPlus/Behaviours/CameraPlusBehaviour.cs
@@ -35,6 +35,7 @@ namespace CameraPlus.Behaviours
         protected const int AlwaysVisible = 10;
         protected const int NoteLayer = 8;
         protected const int CustomNoteLayer = 24;
+        protected const int SaberLayer = 12;
 
         public bool ThirdPerson
         {
@@ -745,6 +746,74 @@ namespace CameraPlus.Behaviours
         internal virtual void SetCullingMask()
         {
             int builder = Camera.main.cullingMask;
+
+            Debug.Log("Greenscreen Mode: " + Config.GreenScreenMode);
+            _cam.backgroundColor = Color.black;
+            _cam.clearFlags = CameraClearFlags.Color;
+
+            if (Config.GreenScreenMode != "off")
+            {
+                builder = 0;
+                if (Config.GreenScreenMode == "transparent")
+                {
+                    _cam.backgroundColor = Color.clear;
+                } else if(Config.GreenScreenMode == "greenscreen")
+                {
+                    _cam.backgroundColor = Color.green;
+                }
+
+                if (Config.GreenScreenAvatar)
+                {
+                    if (Config.thirdPerson || Config.use360Camera)
+                    {
+                        builder |= 1 << OnlyInThirdPerson;
+                        builder &= ~(1 << OnlyInFirstPerson);
+                    }
+                    else
+                    {
+                        builder |= 1 << OnlyInFirstPerson;
+                        builder &= ~(1 << OnlyInThirdPerson);
+                    }
+                    builder |= 1 << AlwaysVisible;
+                }
+                else
+                {
+                    builder &= ~(1 << OnlyInThirdPerson);
+                    builder &= ~(1 << OnlyInFirstPerson);
+                    builder &= ~(1 << AlwaysVisible);
+                }
+                if (Config.GreenScreenDebri != "link")
+                {
+                    if (Config.GreenScreenDebri == "show")
+                        builder |= (1 << NotesDebriLayer);
+                    else
+                        builder &= ~(1 << NotesDebriLayer);
+                }
+                if (Config.GreenScreenNotes)
+                {
+                    builder &= ~(1 << CustomNoteLayer);
+                    builder |= 1 << NoteLayer;
+                }
+                else
+                {
+                    builder &= ~(1 << CustomNoteLayer);
+                    builder &= ~(1 << NoteLayer);
+                }
+                if (Config.GreenScreenSaber)
+                {
+                    builder |= 1 << SaberLayer;
+                } else
+                {
+                    builder &= ~(1 << SaberLayer);
+                }
+
+                _cam.cullingMask = builder;
+                return;
+            }
+
+            _cam.clearFlags = CameraClearFlags.SolidColor;
+            _cam.backgroundColor = Color.black;
+
             if (Config.transparentWalls)
                 builder &= ~(1 << TransparentWallsPatch.WallLayerMask);
             else

--- a/CameraPlus/CameraPlus.csproj
+++ b/CameraPlus/CameraPlus.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Behaviours\ScreenCameraBehaviour.cs" />
     <Compile Include="UI\BehaviourScriptEdit.cs" />
     <Compile Include="UI\MenuCamera2.cs" />
+    <Compile Include="UI\MenuGreenScreen.cs" />
     <Compile Include="UI\MenuDisplayObject.cs" />
     <Compile Include="UI\MenuExternalLink.cs" />
     <Compile Include="UI\MenuLayout.cs" />

--- a/CameraPlus/Configuration/Config.cs
+++ b/CameraPlus/Configuration/Config.cs
@@ -71,6 +71,13 @@ namespace CameraPlus.Configuration
         public int VMCProtocolPort = 39540;
         //public int maxFps = 90;
 
+        // Greenscreen Settings
+        public string GreenScreenMode = "off";
+        public bool GreenScreenSaber = true;
+        public bool GreenScreenNotes = false;
+        public bool GreenScreenAvatar = true;
+        public string GreenScreenDebri = "link";
+
         public event Action<Config> ConfigChangedEvent;
 
         private readonly FileSystemWatcher _configWatcher;

--- a/CameraPlus/UI/ContextMenu.cs
+++ b/CameraPlus/UI/ContextMenu.cs
@@ -16,7 +16,8 @@ namespace CameraPlus.UI
             Profile,
             MovementScript,
             Camera2Converter,
-            ExternalLink
+            ExternalLink,
+            GreenScreen
         }
         internal Vector2 menuPos
         {
@@ -47,6 +48,7 @@ namespace CameraPlus.UI
         private MenuMovementScript menuMovementScript;
         private MenuCamera2 menuCamera2Converter;
         private MenuExternalLink menuExternalLink;
+        private MenuGreenScreen menuGreenScreen;
 
         public void EnableMenu(Vector2 mousePos, CameraPlusBehaviour parentBehaviour)
         {
@@ -65,6 +67,7 @@ namespace CameraPlus.UI
             menuMovementScript = new MenuMovementScript();
             menuCamera2Converter = new MenuCamera2();
             menuExternalLink = new MenuExternalLink();
+            menuGreenScreen = new MenuGreenScreen();
 
             if (this.parentBehaviour.Config.LockScreen)
                 texture = CustomUtils.LoadTextureFromResources("CameraPlus.Resources.Lock.png");
@@ -220,6 +223,8 @@ namespace CameraPlus.UI
                         MenuMode = MenuState.Layout;
                     if (GUI.Button(new Rect(menuPos.x + 5, menuPos.y + 295, 145, 40), new GUIContent("Multiplayer")))
                         MenuMode = MenuState.Multiplayer;
+                    if (GUI.Button(new Rect(menuPos.x + 150, menuPos.y + 295, 145, 40), new GUIContent("Greenscreen Mode")))
+                        MenuMode = MenuState.GreenScreen;
                     if (GUI.Button(new Rect(menuPos.x + 5, menuPos.y + 340, 145, 40), new GUIContent("Profile Saver")))
                         MenuMode = MenuState.Profile;
                     if (GUI.Button(new Rect(menuPos.x + 150, menuPos.y + 340, 145, 40), new GUIContent("MovementScript")))
@@ -258,6 +263,8 @@ namespace CameraPlus.UI
                     menuLayout.DiplayMenu(parentBehaviour, this, menuPos);
                 else if (MenuMode == MenuState.Multiplayer)
                     menuMultiplayer.DiplayMenu(parentBehaviour, this, menuPos);
+                else if (MenuMode == MenuState.GreenScreen)
+                    menuGreenScreen.DisplayMenu(parentBehaviour, this, menuPos);
                 else if (MenuMode == MenuState.Profile)
                     menuProfile.DiplayMenu(parentBehaviour, this, menuPos);
                 else if (MenuMode == MenuState.MovementScript)

--- a/CameraPlus/UI/MenuGreenScreen.cs
+++ b/CameraPlus/UI/MenuGreenScreen.cs
@@ -1,0 +1,105 @@
+﻿using UnityEngine;
+using CameraPlus.Behaviours;
+
+namespace CameraPlus.UI
+{
+    internal class MenuGreenScreen
+    {
+        internal void DisplayMenu(CameraPlusBehaviour parentBehaviour,ContextMenu contextMenu, Vector2 menuPos)
+        {
+            //Greenscreen Activation
+            GUI.Box(new Rect(menuPos.x, menuPos.y + 25, 300, 55), "Greenscreen Mode");
+            if (GUI.Button(new Rect(menuPos.x + 5, menuPos.y + 45, 95, 30), new GUIContent("Off"), parentBehaviour.Config.GreenScreenMode == "off" ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenMode = "off";
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+            if (GUI.Button(new Rect(menuPos.x + 105, menuPos.y + 45, 95, 30), new GUIContent("Transparent"), parentBehaviour.Config.GreenScreenMode == "transparent" ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenMode = "transparent";
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+
+            if (GUI.Button(new Rect(menuPos.x + 205, menuPos.y + 45, 95, 30), new GUIContent("Greenscreen"), parentBehaviour.Config.GreenScreenMode == "greenscreen" ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenMode = "greenscreen";
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+
+            //Debri
+            GUI.Box(new Rect(menuPos.x, menuPos.y + 80, 300, 55), "Display Debri");
+            if (GUI.Button(new Rect(menuPos.x + 5, menuPos.y + 100, 95, 30), new GUIContent("Link InGame"), parentBehaviour.Config.GreenScreenDebri == "link" ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenDebri = "link";
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+            if (GUI.Button(new Rect(menuPos.x + 105, menuPos.y + 100, 95, 30), new GUIContent("Forced Display"), parentBehaviour.Config.GreenScreenDebri == "show" ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenDebri = "show";
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+
+            if (GUI.Button(new Rect(menuPos.x + 205, menuPos.y + 100, 95, 30), new GUIContent("Forced Hide"), parentBehaviour.Config.GreenScreenDebri == "hide" ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenDebri = "hide";
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+
+            //Display Custom and VMC Avatar
+            GUI.Box(new Rect(menuPos.x, menuPos.y + 135, 300, 55), "Display CustomAvatar/VMCAvatar");
+            if (GUI.Button(new Rect(menuPos.x + 5, menuPos.y + 155, 145, 30), new GUIContent("Show Avatar"), parentBehaviour.Config.GreenScreenAvatar ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenAvatar = true;
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+            if (GUI.Button(new Rect(menuPos.x + 150, menuPos.y + 155, 145, 30), new GUIContent("Hide Avatar"), !parentBehaviour.Config.GreenScreenAvatar ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenAvatar = false;
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+
+            //Saber
+            GUI.Box(new Rect(menuPos.x, menuPos.y + 190, 300, 55), "Display Saber");
+            if (GUI.Button(new Rect(menuPos.x + 5, menuPos.y + 210, 145, 30), new GUIContent("Show Saber"), parentBehaviour.Config.GreenScreenSaber ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenSaber = true;
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+            if (GUI.Button(new Rect(menuPos.x + 150, menuPos.y + 210, 145, 30), new GUIContent("Hide Saber"), !parentBehaviour.Config.GreenScreenSaber ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenSaber = false;
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+
+            //Notes
+            GUI.Box(new Rect(menuPos.x, menuPos.y + 245, 300, 55), "Display Notes");
+            if (GUI.Button(new Rect(menuPos.x + 5, menuPos.y + 265, 145, 30), new GUIContent("Show Notes"), parentBehaviour.Config.GreenScreenNotes ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenNotes = true;
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+            if (GUI.Button(new Rect(menuPos.x + 150, menuPos.y + 265, 145, 30), new GUIContent("Hide Notes"), !parentBehaviour.Config.GreenScreenNotes ? contextMenu.CustomEnableStyle : contextMenu.CustomDisableStyle))
+            {
+                parentBehaviour.Config.GreenScreenNotes = false;
+                parentBehaviour.SetCullingMask();
+                parentBehaviour.Config.Save();
+            }
+
+            if (GUI.Button(new Rect(menuPos.x, menuPos.y + 430, 300, 30), new GUIContent("Close GreenScreen Menu")))
+            {
+                contextMenu.MenuMode = ContextMenu.MenuState.MenuTop;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I think having a green screen mode (where nothing shows up except selected objects, with green background) is beneficial for making interesting Beat Saber videos (such as collaboration videos?), so I've been experimenting with it.

In this pull request, I've added a "Greenscreen Mode" menu in CameraPlus which when enabled, it will only show the selected objects only with green background.

This is currently still a _draft pull request_ because I still can't figure out two things:

1. How to make it works **without having to turn off bloom**. Currently, in order for green screen mode to work, bloom need to be turned off.
2. I also added a "transparent" option, where my expectation is that I can overlay one camera on top of the main camera. This top camera will only show some objects, such as my avatar, saber, and notes only, with transparent background. Imagine like putting VMC front view on OBS, except that it shows the saber and the notes too, and you set it up directly in Beat Saber instead of OBS. Currently this option gives black background.

Here's the mod in action:
![Mod in Action](https://media.giphy.com/media/QUh6fcNGjVJHZY4wUY/giphy.gif)

I'm still quite new to Beat Saber modding, so I've created this draft pull request as a discussion whether you think this is a feature worth adding to CameraPlus and also to maybe help to see if there's a way to solve the two problems above. I don't think the 'transparent' mode is necessary, so I think removing it would be the best choice if it's too difficult, but I do love having bloom enabled on my videos which is why I think issue number 1 is quite important to tackle.

