### PR TITLE
fix probably a typo.

### DIFF
--- a/CameraPlus/UI/ContextMenu.cs
+++ b/CameraPlus/UI/ContextMenu.cs
@@ -457,7 +457,7 @@ namespace CameraPlus.UI
                                 }
                                 if (MenuUI.ToggleSwitch(0, 18, "Wall inside", _cameraPlus.Config.Wall, 6, 3, 1.5f))
                                     _cameraPlus.Config.Wall = !_cameraPlus.Config.Wall;
-                                if (MenuUI.ToggleSwitch(6, 18, "Wall inside", _cameraPlus.Config.WallFrame, 6, 3, 1.5f))
+                                if (MenuUI.ToggleSwitch(6, 18, "Wall Frame", _cameraPlus.Config.WallFrame, 6, 3, 1.5f))
                                     _cameraPlus.Config.WallFrame = !_cameraPlus.Config.WallFrame;
                                 if (MenuUI.ToggleSwitch(0, 21, "UI", _cameraPlus.Config.UI, 6, 3, 1.5f))
                                     _cameraPlus.Config.UI = !_cameraPlus.Config.UI;


### PR DESCRIPTION
We have two items with exactly the same text but the different behaviour in the context menu. The latter one seems to be a typo.
Backporting will fix the same problem in the branch `for-1.29.1`.

コンテキストメニューの中に、同じ表記で違う機能の項目があります。おそらく片方がtypoのように思います。
バックポートで、ブランチ`for-1.29.1`の同じ問題が治ります。