### PR TITLE
temporary workaround of room adjust problem #26

### DIFF
--- a/CameraPlus/VMCProtocol/ExternalSender.cs
+++ b/CameraPlus/VMCProtocol/ExternalSender.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
 using CameraPlus.Behaviours;
+using CameraPlus.HarmonyPatches;
 
 namespace CameraPlus.VMCProtocol
 {
@@ -51,8 +52,8 @@ namespace CameraPlus.VMCProtocol
                 {
                     foreach(SendTask sendTask in sendTasks)
                     {
-                        position = sendTask.parentBehaviour.ThirdPersonPos;
-                        rotation = Quaternion.Euler(sendTask.parentBehaviour.ThirdPersonRot);
+                        position = Quaternion.Inverse(RoomAdjustPatch.rotation) * (sendTask.parentBehaviour.ThirdPersonPos - RoomAdjustPatch.position);
+                        rotation = Quaternion.Inverse(RoomAdjustPatch.rotation) * Quaternion.Euler(sendTask.parentBehaviour.ThirdPersonRot);
 
                         sendTask.client.Send("/VMC/Ext/Cam", "Camera", new float[] {
                             position.x, position.y, position.z,


### PR DESCRIPTION
I share the workaround code of #26 .
This code works in our limited environment but I'm not sure if it is a good idea to refer `RoomAdjustPatch` here. Instead it would be smarter to calculate pos/rot from the other reference object that indicates the offset origin.
I thought `CameraPlusController#origin` or `CameraOrigin` might be a candidate for that role, but both did not work in my setup since they were always [0, 0, 0] and never changed.